### PR TITLE
Fix infinite loop

### DIFF
--- a/lib/Symbols.js
+++ b/lib/Symbols.js
@@ -61,7 +61,7 @@ Symbols.getLastNonSymbolTerm = function(node, symbolName) {
       if (Node.Type.isOperator(child, '+')) {
         return Symbols.getLastNonSymbolTerm(child, symbolName);
       }
-      else if (!isSymbolTerm(child, symbolName)) {
+      else if (isNonSymbolTerm(child, symbolName)) {
         return child;
       }
     }
@@ -101,6 +101,10 @@ Symbols.getLastDenominatorWithSymbolTerm = function(node, symbolName) {
 function isSymbolTerm(node, symbolName) {
   return isPolynomialTermWithSymbol(node, symbolName) ||
     hasDenominatorSymbol(node, symbolName);
+}
+
+function isNonSymbolTerm(node, symbolName) {
+  return !Symbols.getSymbolsInExpression(node).has(symbolName);
 }
 
 function isPolynomialTermWithSymbol(node, symbolName) {

--- a/lib/simplifyExpression/stepThrough.js
+++ b/lib/simplifyExpression/stepThrough.js
@@ -59,7 +59,7 @@ function stepThrough(node, debug=false) {
 // Given a mathjs expression node, performs a single step to simplify the
 // expression. Returns a Node.Status object.
 function step(node) {
-  node = node.cloneDeep()
+  node = node.cloneDeep();
   let nodeStatus;
 
   node = flattenOperands(node);

--- a/test/solveEquation/solveEquation.test.js
+++ b/test/solveEquation/solveEquation.test.js
@@ -46,6 +46,9 @@ describe('solveEquation for =', function () {
     ['9x + 4 - 3 = -2x', 'x = -1/11'],
     ['5x + (1/2)x = 27 ', 'x = 54/11'],
     ['2x/3 = 2x - 4', 'x = 3'],
+    ['2 - ((1)/(2)) x = 1', 'x = 2'],
+    ['2 + -(((1)/(2))*x) = 1', 'x = 2'],
+    ['3 - (x*3) = 4', 'x = -1/3'],
     ['(-2/3)x + 3/7 = 1/2', 'x = -3/28'],
     ['-(9/4)v + 4/5 = 7/8 ', 'v = -1/30'],
     // TODO: update test once we have root support
@@ -170,6 +173,9 @@ describe('constant comparison support', function () {
     ['( r )/( ( r ) ) = ( 1)/( 10)', ChangeTypes.STATEMENT_IS_FALSE],
     ['5 + (x - 5) = x', ChangeTypes.STATEMENT_IS_TRUE],
     ['4x - 4= 4x', ChangeTypes.STATEMENT_IS_FALSE],
+    // TODO: our fork fails these cases where the original does not - fix?
+    // ['x - 1/x = x - 1/x', ChangeTypes.STATEMENT_IS_TRUE],
+    // ['4x - 4/x = 4x', ChangeTypes.STATEMENT_IS_FALSE],
   ];
   tests.forEach(t => testSolveConstantEquation(t[0], t[1], t[2]));
 });

--- a/test/util/removeUnnecessaryParens.test.js
+++ b/test/util/removeUnnecessaryParens.test.js
@@ -25,6 +25,11 @@ describe('removeUnnecessaryParens', function () {
     ['(x+4) - (12 + x)', 'x + 4 - (12 + x)'],
     ['(2x)^2', '(2x)^2'],
     ['((4+x)-5)^(2)', '(4 + x - 5)^2'],
+    // TODO: removeUnnecessaryParens does not always remove all unnecessary parens in a single pass
+    // For example, the output below is acheived only by running the input through rUP at least twice
+    // ['((3)/2) * x', '3/2 x']
+    // This behavior was already the partial cause of one bug (which was fixed in a different way),
+    // so if we notice it causing additional issues in the future we probably want to address.
   ];
   tests.forEach(t => testRemoveUnnecessaryParens(t[0], t[1]));
 });


### PR DESCRIPTION
We discovered a bug where equations like `4 - ((3)/(2))x = 1` would not solve correctly, getting caught in an infinite loop of shifting the `((3)/(2))x` term back and forth between the two sides of the equation.

It turned out this was happening essentially due to `((3)/(2))x` being incorrectly identified as a non-symbol term (i.e. term without a variable), and this fix simplifies the logic of that identification.